### PR TITLE
KA9Q-Radio Support

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           # cache-from: type=local,src=/tmp/buildx-cache
           # cache-to: type=local,dest=/tmp/buildx-cache-new,mode=max
           push: ${{ github.event_name != 'pull_request' }}
@@ -58,11 +58,11 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           # cache-from: type=local,src=/tmp/buildx-cache
           # cache-to: type=local,dest=/tmp/buildx-cache-new,mode=max
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/xssfox/sstv-skimmer:drm
+          tags: ghcr.io/darksidelemm/sstv-skimmer:drm
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             QSSTV_CONFIG=qsstv_9.0_drm.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG QSSTV_CONFIG=qsstv_9.0.conf
@@ -16,7 +16,7 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y install --no-install-r
     libairspy-dev libairspyhf-dev libavahi-client-dev libbsd-dev \
     libfftw3-dev libhackrf-dev libiniparser-dev libncurses5-dev \
     libopus-dev librtlsdr-dev libusb-1.0-0-dev libusb-dev \
-    portaudio19-dev libasound2-dev libogg-dev uuid-dev rsync && rm -rf /var/lib/apt/lists/*
+    portaudio19-dev libasound2-dev libogg-dev uuid-dev rsync unzip && rm -rf /var/lib/apt/lists/*
 
 # spy server
 RUN git clone https://github.com/miweber67/spyserver_client.git && cd spyserver_client && make && cp ss_client /usr/bin/ss_iq

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG QSSTV_CONFIG=qsstv_9.0.conf
 
 RUN apt-get update && apt-get install -y libfftw3-dev libfftw3-3 ffmpeg \
 xvfb qsstv pulseaudio build-essential git libsamplerate0-dev alsa-utils \
-xvfb python3 python3-pip cmake portaudio19-dev python-dev python3-opencv \
+xvfb python3 python3-pip cmake portaudio19-dev python3-dev python3-opencv \
 alsa-utils rtl-sdr
 
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,37 @@ RUN sed -i -re 's/ports.ubuntu.com\/ubuntu-ports|security.ubuntu.com\/ubuntu-por
 RUN apt-get update && apt-get install -y libfftw3-dev libfftw3-3 ffmpeg \
 xvfb qsstv pulseaudio build-essential git libsamplerate0-dev alsa-utils \
 xvfb python3 python3-pip cmake portaudio19-dev python-dev python3-opencv \
-alsa-utils rtl-sdr && rm -rf /var/lib/apt/lists/*
+alsa-utils rtl-sdr
+
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install --no-install-recommends \
+    cmake build-essential ca-certificates git libusb-1.0-0-dev \
+    libatlas-base-dev libsoapysdr-dev soapysdr-module-all \
+    libairspy-dev libairspyhf-dev libavahi-client-dev libbsd-dev \
+    libfftw3-dev libhackrf-dev libiniparser-dev libncurses5-dev \
+    libopus-dev librtlsdr-dev libusb-1.0-0-dev libusb-dev \
+    portaudio19-dev libasound2-dev libogg-dev uuid-dev rsync && rm -rf /var/lib/apt/lists/*
 
 # spy server
 RUN git clone https://github.com/miweber67/spyserver_client.git && cd spyserver_client && make && cp ss_client /usr/bin/ss_iq
 #csdr
 RUN cd / && git clone https://github.com/jketterl/csdr.git && cd csdr && git checkout master && mkdir -p build && cd build && cmake .. && make && make install && ldconfig
+
+
+# ka9q-radio commit:
+ARG KA9Q_REF=cc22b5f5e3c26c37df441ebff29eea7d59031afd
+
+# Compile and install pcmcat and tune from KA9Q-Radio
+ADD https://github.com/ka9q/ka9q-radio/archive/$KA9Q_REF.zip /tmp/ka9q-radio.zip
+RUN unzip /tmp/ka9q-radio.zip -d /tmp && \
+  cd /tmp/ka9q-radio-$KA9Q_REF && \
+  make \
+    -f Makefile.linux \
+    ARCHOPTS= \
+    pcmrecord tune && \
+  cp pcmrecord /usr/bin/ && \
+  cp tune /usr/bin/ && \
+  rm -rf /root/ka9q-radio
+
 # python dependencies
 RUN pip3 install Mastodon.py watchdog soundmeter requests
 #pulse server requiremeent

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,14 @@ xvfb qsstv pulseaudio build-essential git libsamplerate0-dev alsa-utils \
 xvfb python3 python3-pip cmake portaudio19-dev python3-dev python3-opencv \
 alsa-utils rtl-sdr
 
+# Utilities needed for ka9q-radio build
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install --no-install-recommends \
     cmake build-essential ca-certificates git libusb-1.0-0-dev \
     libatlas-base-dev libsoapysdr-dev soapysdr-module-all \
     libairspy-dev libairspyhf-dev libavahi-client-dev libbsd-dev \
     libfftw3-dev libhackrf-dev libiniparser-dev libncurses5-dev \
     libopus-dev librtlsdr-dev libusb-1.0-0-dev libusb-dev \
-    portaudio19-dev libasound2-dev libogg-dev uuid-dev rsync unzip && rm -rf /var/lib/apt/lists/*
+    portaudio19-dev libasound2-dev libogg-dev uuid-dev avahi-utils libnss-mdns unzip && rm -rf /var/lib/apt/lists/*
 
 # spy server
 RUN git clone https://github.com/miweber67/spyserver_client.git && cd spyserver_client && make && cp ss_client /usr/bin/ss_iq
@@ -27,7 +28,7 @@ RUN cd / && git clone https://github.com/jketterl/csdr.git && cd csdr && git che
 # ka9q-radio commit:
 ARG KA9Q_REF=cc22b5f5e3c26c37df441ebff29eea7d59031afd
 
-# Compile and install pcmcat and tune from KA9Q-Radio
+# Compile and install pcmrecord and tune from KA9Q-Radio
 ADD https://github.com/ka9q/ka9q-radio/archive/$KA9Q_REF.zip /tmp/ka9q-radio.zip
 RUN unzip /tmp/ka9q-radio.zip -d /tmp && \
   cd /tmp/ka9q-radio-$KA9Q_REF && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG QSSTV_CONFIG=qsstv_9.0.conf
 
-RUN sed -i -re 's/ports.ubuntu.com\/ubuntu-ports|security.ubuntu.com\/ubuntu-ports|archive.ubuntu.com\/ubuntu|security.ubuntu.com\/ubuntu/old-releases.ubuntu.com\/ubuntu/g' /etc/apt/sources.list
+#RUN sed -i -re 's/ports.ubuntu.com\/ubuntu-ports|security.ubuntu.com\/ubuntu-ports|archive.ubuntu.com\/ubuntu|security.ubuntu.com\/ubuntu/old-releases.ubuntu.com\/ubuntu/g' /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y libfftw3-dev libfftw3-3 ffmpeg \
 xvfb qsstv pulseaudio build-essential git libsamplerate0-dev alsa-utils \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Skims SSTV off spyservers using QSSTV and uploads to mastodon. This is a WIP and shouldn't be considered as stable.
+Skims SSTV off a ka9q-radio or spyserver instance using QSSTV and uploads to mastodon. This is a WIP and shouldn't be considered as stable.
 
 > You may also need `--security-opt seccomp=unconfined` due to security restrictions on high resolution timers.
 
@@ -15,6 +15,8 @@ docker run \
 -e MODE=USB \
 --restart always \
 --name sstv-20 \
+-v /var/run/dbus:/var/run/dbus \
+-v /var/run/avahi-daemon/socket:/var/run/avahi-daemon/socket \
 ghcr.io/xssfox/sstv-skimmer:latest
 ```
 
@@ -26,10 +28,10 @@ These need to be in order for the skimmer to work
 
 | Name | Description                                                                                                  |
 | ---- | ------------------------------------------------------------------------------------------------------------ |
-| HOST | spy server hostname                                                                                          | 
+| HOST | spy server hostname OR ka9q-radio PCM host (e.g. sstvlsb-pcm.local)                                          | 
 | PORT | spy server port port                                                                                         |
-| FREQ | frequency for USB in HZ                                                                                      |
-| MODE | USB or LSB                                                                                                   |
+| FREQ | frequency for USB/LSB in Hz                                                                                  |
+| MODE | USB, LSB or KA9Q                                                                                             |
 | M_USERNAME | User name for mastodon instance                                                                        |
 | M_PASSWORD | Password for mastodon instance                                                                         |
 | M_URL |  Mastodon url eg : "https://botsin.space"                                                                   |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ docker run \
 -e M_URL="https://botsin.space" \
 -e M_CLIENT_ID='' \
 -e M_CLIENT_SECRET='' \
+-e SOURCE=SpyServer \
 -e MODE=USB \
 --restart always \
 --name sstv-20 \
@@ -29,9 +30,10 @@ These need to be in order for the skimmer to work
 | Name | Description                                                                                                  |
 | ---- | ------------------------------------------------------------------------------------------------------------ |
 | HOST | spy server hostname OR ka9q-radio PCM host (e.g. sstvlsb-pcm.local)                                          | 
-| PORT | spy server port port                                                                                         |
+| PORT | spy server port (unused for ka9q-radio)                                                                      |
 | FREQ | frequency for USB/LSB in Hz                                                                                  |
-| MODE | USB, LSB or KA9Q                                                                                             |
+| SOURCE | KA9Q, SpyServer, or RTLSDR                                                                                 |
+| MODE | USB, LSB or FM                                                                                               |
 | M_USERNAME | User name for mastodon instance                                                                        |
 | M_PASSWORD | Password for mastodon instance                                                                         |
 | M_URL |  Mastodon url eg : "https://botsin.space"                                                                   |

--- a/run.sh
+++ b/run.sh
@@ -43,6 +43,10 @@ then
     csdr convert_s16_f |\
     csdr bandpass_fir_fft_cc 0 0.3 0.05 | csdr realpart_cf | csdr agc_ff | csdr limit_ff | \
     csdr convert_f_s16 | aplay -r 12000 -f s16 -t raw -c 1 - &
+elif [ "$MODE" == "KA9Q" ]
+then
+    echo "Using KA9Q Radio for SSB reception (ka9q-radio sets the sideband)"
+    pcmrecord --ssrc $FREQ --catmode --raw $HOST | aplay -r 12000 -f s16 -t raw -c 1 - &
 elif [ "$MODE" == "RTLFM" ]
 then
     echo "Using RTLSDR for FM reception"

--- a/run.sh
+++ b/run.sh
@@ -28,7 +28,7 @@ export PYTHONUNBUFFERED=1
 echo "Starting poster"
 python3 /poster.py &
 
-#run spy client
+# Start up the RF source
 if [ "$SOURCE" == "SpyServer" ]
 then
     if [ "$MODE" == "LSB" ]


### PR DESCRIPTION
Adds installation of ka9q-radio dependencies, builds the pcmrecord and tune utilities (we actually only use pcmrecord), and adds a KA9Q mode option.

When using the KA9Q mode, the sideband is set by the ka9q-radio server configuration for the particular SSRC in use. 